### PR TITLE
FontAwesome 5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ capitalize each word after the first one).
     {!! fa()->icon('window-close') !!}
     {!! fa()->windowClose() !!}
 
+If you want to use different icon styles provided by FontAwesome 5, you can easily add a style parameter to the fa() or
+use different helpers for the corresponding icon style. (You can also set the default style in the config file)
+
+    {!! fa('r')->icon('address-book') !!}
+    {!! far()->icon('address-book') !!}
+
 ### Modifiers
 
 You can chain methods to affect the icon.

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,12 @@
             "email" : "contact@vincentprat.info",
             "homepage" : "https://vincentprat.info",
             "role" : "Developer"
+        },
+        {
+            "name" : "Chan-Yuan Hsu",
+            "email" : "jyhsu2000@gmail.com",
+            "homepage" : "https://kid7.club",
+            "role" : "Developer"
         }
     ],
     "require" : {

--- a/config/laravel_html_font_awesome.php
+++ b/config/laravel_html_font_awesome.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    /*
+     |--------------------------------------------------------------------------
+     | Default Icon Style
+     |--------------------------------------------------------------------------
+     |
+     | There are 4 different prefixes for set the style of any icon in FontAwesome 5.
+     | You can use fa() with parameter (e.g. fa('s')) or use different helpers (e.g. fas()) for specify style,
+     | or just change this value to specify icon style when you use just fa()
+     |
+     | Available value:
+     |      's' or '' or 'solid'  for Font Awesome Solid
+     |      'r' or 'regular'      for Font Awesome Regular
+     |      'l' or 'light'        for Font Awesome Light
+     |      'd' or 'duotone'      for Font Awesome Duotone
+     |      'b' or 'brands'       for Font Awesome Brands
+     |
+     | @see https://fontawesome.com/how-to-use/on-the-web/referencing-icons/basic-use
+     */
+    'default_icon_style' => 's'
+];

--- a/config/laravel_html_font_awesome.php
+++ b/config/laravel_html_font_awesome.php
@@ -6,7 +6,7 @@ return [
      | Default Icon Style
      |--------------------------------------------------------------------------
      |
-     | There are 4 different prefixes for set the style of any icon in FontAwesome 5.
+     | There are 5 different prefixes for set the style of any icon in FontAwesome 5.
      | You can use fa() with parameter (e.g. fa('s')) or use different helpers (e.g. fas()) for specify style,
      | or just change this value to specify icon style when you use just fa()
      |

--- a/src/FontAwesome/Elements/FontAwesomeIcon.php
+++ b/src/FontAwesome/Elements/FontAwesomeIcon.php
@@ -18,12 +18,17 @@ class FontAwesomeIcon extends BaseElement
      * Set the icon to be used
      *
      * @param string $name Name of the icon (without any 'fa-' prefix)
-     *
+     * @param string $iconStyle Icon style in single letter (Available: 's', 'r', 'l', 'd', 'b')
      * @return static
      */
-    public function name($name)
+    public function name($name, $iconStyle = null)
     {
-        return $this->addClass(['fa', "fa-{$name}"]);
+        // Get specified icon style
+        $iconStyle = !empty($iconStyle) ? $iconStyle : config('laravel_html_font_awesome.default_icon_style');
+        // Keep icon style as an single lowercase letter
+        $iconStyle = strtolower(mb_substr($iconStyle, 0, 1));
+
+        return $this->addClass(["fa{$iconStyle}", "fa-{$name}"]);
     }
 
     /**

--- a/src/FontAwesome/FontAwesome.php
+++ b/src/FontAwesome/FontAwesome.php
@@ -2,6 +2,7 @@
 
 namespace MarvinLabs\Html\FontAwesome;
 
+use Illuminate\Support\Str;
 use MarvinLabs\Html\FontAwesome\Elements\FontAwesomeIcon;
 use Spatie\Html\Html;
 
@@ -102,7 +103,7 @@ class FontAwesome
     {
         if (empty($arguments))
         {
-            return $this->icon(kebab_case($name));
+            return $this->icon(Str::kebab($name));
         }
     }
 

--- a/src/FontAwesome/FontAwesome.php
+++ b/src/FontAwesome/FontAwesome.php
@@ -18,15 +18,19 @@ class FontAwesome
 
     /** @var \Spatie\Html\Html */
     protected $html;
+    /** @var string */
+    private $iconStyle;
 
     /**
      * FontAwesome constructor.
      *
      * @param \Spatie\Html\Html $html
+     * @param string $iconStyle
      */
-    public function __construct(Html $html)
+    public function __construct(Html $html, $iconStyle)
     {
         $this->html = $html;
+        $this->iconStyle = $iconStyle;
     }
 
     /**
@@ -52,7 +56,7 @@ class FontAwesome
      */
     public function icon($name)
     {
-        return FontAwesomeIcon::create()->name($name);
+        return FontAwesomeIcon::create()->name($name, $this->iconStyle);
     }
 
     /**

--- a/src/FontAwesome/FontAwesomeServiceProvider.php
+++ b/src/FontAwesome/FontAwesomeServiceProvider.php
@@ -12,6 +12,20 @@ use Illuminate\Support\ServiceProvider;
  */
 class FontAwesomeServiceProvider extends ServiceProvider
 {
+    /**
+     * Bootstrap the application services.
+     */
+    public function boot()
+    {
+        $this->mergeConfigFrom(__DIR__ . '/../../config/laravel_html_font_awesome.php', 'laravel_html_font_awesome');
+
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__ . '/../../config' => config_path(),
+            ], 'config');
+        }
+    }
+
 
     /**
      * Register the application services.

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -2,14 +2,69 @@
 
 use MarvinLabs\Html\FontAwesome\FontAwesome;
 
-if ( !function_exists('fa'))
-{
+if (!function_exists('fa')) {
+
+    /**
+     * @param string $iconStyle
+     * @return \MarvinLabs\Html\FontAwesome\FontAwesome
+     */
+    function fa($iconStyle = null)
+    {
+        return app(FontAwesome::class, ['iconStyle' => $iconStyle]);
+    }
+}
+
+if (!function_exists('fas')) {
 
     /**
      * @return \MarvinLabs\Html\FontAwesome\FontAwesome
      */
-    function fa()
+    function fas()
     {
-        return app(FontAwesome::class);
+        return app(FontAwesome::class, ['iconStyle' => 's']);
+    }
+}
+
+if (!function_exists('far')) {
+
+    /**
+     * @return \MarvinLabs\Html\FontAwesome\FontAwesome
+     */
+    function far()
+    {
+        return app(FontAwesome::class, ['iconStyle' => 'r']);
+    }
+}
+
+if (!function_exists('fal')) {
+
+    /**
+     * @return \MarvinLabs\Html\FontAwesome\FontAwesome
+     */
+    function fal()
+    {
+        return app(FontAwesome::class, ['iconStyle' => 'l']);
+    }
+}
+
+if (!function_exists('fad')) {
+
+    /**
+     * @return \MarvinLabs\Html\FontAwesome\FontAwesome
+     */
+    function fad()
+    {
+        return app(FontAwesome::class, ['iconStyle' => 'd']);
+    }
+}
+
+if (!function_exists('fab')) {
+
+    /**
+     * @return \MarvinLabs\Html\FontAwesome\FontAwesome
+     */
+    function fab()
+    {
+        return app(FontAwesome::class, ['iconStyle' => 'b']);
     }
 }


### PR DESCRIPTION
As discussed in #6
I added parameter support and more helpers for different icon styles provided by FontAwesome 5
Here is some example of usage:
```php
# Use different helpers for different style
far()->icon('check')
# Add a style parameter in fa()
fa('r')->icon('check')
fa('regular')->icon('check')
```

And the following is what I have done in the PR
- Use `Str::kebab` instead of `kebab_case` to support new Laravel versions without install [Laravel Helpers](https://github.com/laravel/helpers).
- Support [all icon styles provided by FontAwesome 5](https://fontawesome.com/how-to-use/on-the-web/referencing-icons/basic-use) (Solid, Regular, Light, Duotone, Brands) in two ways (parameter or helpers)
- Create a config file for setting default icon style when use only `fa()` without style parameter.
